### PR TITLE
fix problem with ternary-operator

### DIFF
--- a/test/bug/ternary_operator.pil
+++ b/test/bug/ternary_operator.pil
@@ -1,0 +1,18 @@
+int a = 23;
+int b = 1;
+
+int res;
+
+res = a > 25 ? 1 : (1 - b);
+println(res);
+assert(res == 0);
+
+res = a > 15 ? 1 : (1 - b);
+println(res);
+assert(res == 1);
+
+a = 30;
+res = a > 25 ? 1 : (1 - b);
+println(res);
+assert(res == 1);
+


### PR DESCRIPTION
Fix a generic bug with stack relative offset calculation when a operation has more than 2 operands and these operands not are direct values (alone values).