### PR TITLE
Fix bug with ternary operation and non alone expressions

### DIFF
--- a/src/expression/translation_table.js
+++ b/src/expression/translation_table.js
@@ -4,10 +4,17 @@ module.exports = class TranslationTable {
     constructor () {
         this.values = [];
     }
+    initWithAllToPurge(originalLength, purge) {        
+        let nextNewPos = 0;
+        for (let pos = 0; pos < originalLength; ++pos) {
+            if (purge[pos]) this.savePurge(pos);
+            else this.translate(pos, nextNewPos++);
+        }
+    }
     translate(pos, newPos) {
         this.values[pos] = {newPos, operand: false, purge: false};
     }
-    savePurge(pos, operand) {
+    savePurge(pos, operand = false) {
         this.values[pos] = {newPos: false, operand, purge: true};
     }
     copyPurge(pos, sourcePos) {

--- a/src/processor.js
+++ b/src/processor.js
@@ -396,7 +396,7 @@ module.exports = class Processor {
         this.scope.pop();
         --this.functionDeep;
         this.callstack.pop();
-        if (Debug.active) console.log(`END CALL ${func.name}`, res);
+        if (Debug.active) console.log(`END CALL ${func.name}`);
     }
     executeFunctionCall(name, callinfo, options = {}) {
         const func = this.builtIn[name] ?? this.references.get(name);

--- a/test/bug/minus_unary.pil
+++ b/test/bug/minus_unary.pil
@@ -1,0 +1,13 @@
+col witness a;
+expr _a = -a;
+expr _b = 3 * a;
+expr _c = -_b;
+
+println(_a);
+assert_eq(string(_a), "-a");
+
+println(_b);
+assert_eq(string(_b), "3 * a");
+
+println(_c);
+assert_eq(string(_c), "-(3 * a)");

--- a/test/bug/ternary_operator.pil
+++ b/test/bug/ternary_operator.pil
@@ -33,3 +33,19 @@ println(a);
 
 a = -(2)**8;
 println(a);
+
+
+function f(int c, expr sel) {
+    expr _a0 = sel;
+    expr _a1 = 0 - sel;
+    expr _a = c ? sel : 0 - sel;
+    println("=====> ", c);
+    println(_a0);
+    println(_a1);
+    println(_a);
+}
+
+col witness w;
+f(0, w * w);
+f(1, w * w);
+

--- a/test/bug/ternary_operator_expr.pil
+++ b/test/bug/ternary_operator_expr.pil
@@ -1,9 +1,12 @@
 col witness w0,w1,  w2,w3;
 expr _a = 2 * w2;
 expr _b = 3 * w3;
+
+assert(string(_a) == "2 * w2");
+assert(string(_b) == "3 * w3");
+
 int sel = 0;
-#pragma debug on
-expr __res = sel ? w0  : 0 - _a;
+expr __res = sel ? _a : 0 - _b;
 println(__res);
 /*
 int b = 1;

--- a/test/bug/ternary_operator_expr.pil
+++ b/test/bug/ternary_operator_expr.pil
@@ -2,18 +2,17 @@ col witness w0,w1,  w2,w3;
 expr _a = 2 * w2;
 expr _b = 3 * w3;
 
-assert(string(_a) == "2 * w2");
-assert(string(_b) == "3 * w3");
+assert_eq(string(_a), "2 * w2");
+assert_eq(string(_b), "3 * w3");
 
 int sel = 0;
-expr __res = sel ? _a : 0 - _b;
-println(__res);
-/*
-int b = 1;
+expr _res = sel ? _a : 0 - _b;
+assert_eq(string(_res), "0 - 3 * w3");
 
-expr __res = b ? w2 : 0 - w2;
-println(__res);
+sel = 1;
+_res = _res + (sel ? _a : 0 - _b);
+assert_eq(string(_res), "0 - 3 * w3 + 2 * w2");
 
-b=0;
-__res = b ? w2 : 0 - w2;
-println(__res);*/
+sel = 0;
+_res = sel ? _a : - _b; 
+assert_eq(string(_res), "-(3 * w3)");

--- a/test/bug/ternary_operator_expr.pil
+++ b/test/bug/ternary_operator_expr.pil
@@ -1,0 +1,16 @@
+col witness w0,w1,  w2,w3;
+expr _a = 2 * w2;
+expr _b = 3 * w3;
+int sel = 0;
+#pragma debug on
+expr __res = sel ? w0  : 0 - _a;
+println(__res);
+/*
+int b = 1;
+
+expr __res = b ? w2 : 0 - w2;
+println(__res);
+
+b=0;
+__res = b ? w2 : 0 - w2;
+println(__res);*/


### PR DESCRIPTION
The expressions use a stack of operation, in special case ot ternary operation when operators have more than one element. on top of stack is the ternary operator with relative stack positions. After that, the part of the true operations, and after the false part. When simplify by false, simplify the top stack position, but not remove the true part that remain on top of stack. Top of stack is the result of operation. 

With the fix, now the first step on each loop of simplification was purge the orphan part of stack.