### PR TITLE
add support to int arrays and direct ints on hints

### DIFF
--- a/src/pil.js
+++ b/src/pil.js
@@ -24,6 +24,8 @@ const OPTIONS = {
     'no-proto-fixed-data': { describe: 'no store data of fixed inside pilout' },
     'output-constraints': { describe: 'output all air and global constraints generated' },
     'output-global-constraints': { describe: 'output all global constraints generated' },
+    'raw-constraints-format': { describe: 'if output constraints are enabled only in raw format' },
+    'both-constraints-format': { describe: 'if output constraints are enabled show named and raw format' },
     'ignore-unknown-pragmas': { describe: 'ignore unknown pragmas' }
     // TODO: option to force witness name as snake_case and air, airtemplate, airgroup in CamelCase
 }

--- a/src/proto_out.js
+++ b/src/proto_out.js
@@ -6,6 +6,7 @@ const util = require('util');
 const assert = require('./assert.js');
 const Context = require('./context.js');
 const StringValue = require('./expression_items/string_value.js');
+const IntValue = require('./expression_items/int_value.js');
 
 const MAX_CHALLENGE = 200;
 const MAX_STAGE = 20;
@@ -536,6 +537,9 @@ module.exports = class ProtoOut {
                 if (value.isString) {
                     return { stringValue: value.asString() };
                 }
+                if (value instanceof IntValue) {
+                    return { operand: {constant: { value: this.bint2buf(value.asInt())}} }
+                }
             }
             const expressionId = hdata.pack(options.packed, options);
             return { operand: { expression: { idx: expressionId } }};
@@ -550,6 +554,9 @@ module.exports = class ProtoOut {
         }
         if (typeof hdata === 'bigint' || typeof hdata === 'number') {
             return { operand: {constant: { value: this.bint2buf(BigInt(hdata))}} }
+        }
+        if (hdata instanceof IntValue) {
+            return { operand: {constant: { value: this.bint2buf(hdata.asInt())}} }
         }
         if (typeof hdata === 'string') {
             return { stringValue: hdata };

--- a/test/features/hints_int.pil
+++ b/test/features/hints_int.pil
@@ -1,0 +1,22 @@
+public input1;
+
+airtemplate Hints(int N = 2**16) {
+
+    col witness stage(2) gsum;
+    col witness stage(3) gsum2;
+
+    int value = 12;
+    @my_hint_with_int {value: 10}
+    @my_hint_with_int2 {value: value}
+    @my_hint_with_array_int {values: [3,6,9,12]}
+    int values[5] = [5,10,15,20,25];
+    @my_hint_with_array_int2 {values: values}
+
+    gsum + gsum2 === N;
+}
+
+input1 === 3;
+
+airgroup Hints {
+    Hints(2**10);
+}


### PR DESCRIPTION
- support to use int arrays on hints
- support to use int direct arrays o int direct values on hints, without create auxiliary expressions.
- new command line options:
    - **raw-constraints-format**  to output constraints only in raw format (*), 
    - **both-constraints-format** to output constraints using names and  in raw format (*)
- with --verbose option now show stack on internal compiler exceptions.

(*) this option only applies when output-constraints or output-global-constraints are enabled.
