### PR TITLE
fix false size error when assign sequence to array.

### DIFF
--- a/src/definition_items/fixed_col.js
+++ b/src/definition_items/fixed_col.js
@@ -230,6 +230,10 @@ module.exports = class FixedCol extends ProofItem {
             throw new Error('Assign a sequence when has values');
         }
         if (value.isSequence) {
+            const max_rows = this.rows ? this.rows : Context.rows;
+            if (value.size > max_rows) {
+                throw new Error(`Invalid sequence size, sequence is too large, it has size of ${value.size} but number of rows is ${max_rows}, size exceeds in ${value.size - max_rows}`);
+            }
             this.sequence = value;
             this.rows = this.sequence.size;
             return;

--- a/src/sequence.js
+++ b/src/sequence.js
@@ -59,9 +59,6 @@ module.exports = class Sequence {
         };
         this.engines.typeOf.execute(this.expression);
         this.sizeOf(this.expression);
-        if (this.size > Context.rows) {
-            throw new Error(`Invalid sequence size, sequence is too large, it has size of ${this.size} but number of rows is ${Context.rows}, size exceeds in ${this.size - Context.rows}`);
-        }
         this.#values = new Values(this.bytes, this.size);
     }
     get isSequence () {

--- a/test/bug/fix_sequence_size.pil
+++ b/test/bug/fix_sequence_size.pil
@@ -1,0 +1,14 @@
+airtemplate FixSequenceSize(int N = 2**2) {
+    col fixed virtual(5) MY_VIRT_SEQ = [1,2,3,4,5];
+    // col fixed MY_SEQ = [1,2,3,4,5];
+    const int inside_groups_by_opid[2][5];
+    inside_groups_by_opid[0] = [7, 4, 5, 2, 3];
+
+}
+
+const int groups_by_opid[2][5];
+groups_by_opid[0] = [7, 4, 5, 2, 3];
+
+airgroup FixSequenceSizeGroup {
+    FixSequenceSize();
+}


### PR DESCRIPTION
When a sequence was created, verifies the size, but this verification must be done when assigns this sequence to fixed non virtual column. It's possible assign directly a sequence to array, in this case this verifies fail but the instruction was correct.