### PR TITLE
Fix/msg error hints

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -687,15 +687,18 @@ module.exports = class Processor {
         if (Debug.active) console.log(util.inspect(s.data, false, null, true));
         const res = this.processHintData(s.data);
         if (Debug.active) console.log(util.inspect(res, false, null, true));
-        if (this.scope.getInstanceType() === 'proof') {
+        const scopeType = this.scope.getInstanceType();
+        if (scopeType === 'proof') {
             if (Context.config.logHints) console.log(`  > define global hint \x1B[38;5;208m${name}\x1B[0m`)
             this.globalHints.define(name, res);
         }
-        else {
+        else if (scopeType == 'air') {
             if (Context.config.logHints || Context.config.logGlobalHints) {
                 console.log(`  > define hint \x1B[38;5;208m${name}\x1B[0m`)
             }
             this.hints.define(name, res);
+        } else {
+            throw new Error(`Hint definition on invalid scope (${scopeType}) ${sourceTag}`);
         }
     }
     processHintData(hdata) {

--- a/src/processor.js
+++ b/src/processor.js
@@ -698,7 +698,7 @@ module.exports = class Processor {
             }
             this.hints.define(name, res);
         } else {
-            throw new Error(`Hint definition on invalid scope (${scopeType}) ${sourceTag}`);
+            throw new Error(`Hint definition on invalid scope (${scopeType}) ${Context.sourceTag}`);
         }
     }
     processHintData(hdata) {


### PR DESCRIPTION
The compiler doesn't check the proof scope when a hint was created, there are only two scopes, proof (globlal) or air. Now if the scope isn't correct an error will be reported.