### PR TITLE
develop 0.8.0

### DIFF
--- a/src/definition_items/fixed_col.js
+++ b/src/definition_items/fixed_col.js
@@ -230,6 +230,10 @@ module.exports = class FixedCol extends ProofItem {
             throw new Error('Assign a sequence when has values');
         }
         if (value.isSequence) {
+            const max_rows = this.rows ? this.rows : Context.rows;
+            if (value.size > max_rows) {
+                throw new Error(`Invalid sequence size, sequence is too large, it has size of ${value.size} but number of rows is ${max_rows}, size exceeds in ${value.size - max_rows}`);
+            }
             this.sequence = value;
             this.rows = this.sequence.size;
             return;

--- a/src/features.js
+++ b/src/features.js
@@ -53,9 +53,9 @@ module.exports = class Features {
         }
         return {...defaultFeatures,...featuresExtracted};
     }
-    static extractArguments(featureCls, feature) {
+    static extractArguments(featureCls, feature) {        
         const config = featureCls.config;
-        const args = feature.args.eval({clone: true}).items;
+        const args = feature.args.items;
         if (args.length < config.minArgs || args.length > config.maxArgs) {
             throw new Error(`Invalid number of arguments for feature ${feature.name} at ${Context.sourceTag}`);
         }
@@ -96,11 +96,11 @@ module.exports = class Features {
         return res;
     }   
     static getOptionArgument(arg, feature, index, argConfig) {
-        const value = ExpressionItem.value2string(arg);
+        let value = (arg.getAlone() ?? false).name ?? false;
         if (value === false) {
             throw new Error(`Invalid argument type for feature ${feature.name} at index ${index}, expected string but found ${typeof arg} at ${Context.sourceTag}`);
         }
-        if (!argConfig.values.includes(arg)) {
+        if (!argConfig.values.includes(value)) {
             throw new Error(`Invalid argument value for feature ${feature.name} at index ${index}, expected one of ${argConfig.values.join(', ')} but found ${arg} at ${Context.sourceTag}`);
         }
         return value;

--- a/src/processor.js
+++ b/src/processor.js
@@ -1673,7 +1673,20 @@ module.exports = class Processor {
     }
     execWitnessColDeclaration(s) {
         const features = Features.extractFeatures('witness', s.features, {stage: true});
-        this.declare(s, 'witness', false, true, features);
+        let res = this.declare(s, 'witness', false, true, features);
+        if (features.bits !== undefined) {            
+            for (let [name, id] of res) {
+                let lastNameIndex = name.lastIndexOf('.');
+                if (lastNameIndex !== -1) {
+                    name = name.substring(lastNameIndex + 1);
+                }
+                let hint ={name, bits: features.bits[0]};
+                if (features.bits[1] == 'signed') {
+                    hint.signed = 1;
+                }
+                this.hints.define('witness_bits', hint);
+            }
+        }
     }
     execCustomColDeclaration(s) {
         let commit = this.commits.get(s.commit);
@@ -1912,16 +1925,21 @@ module.exports = class Processor {
         return this.decodeIndexes(s.lengths);
     }
     declare(s, type, ignoreInit, fullName = true, data = {}) {
+        let res = [];
         for (const col of s.items) {
             const lengths = this.decodeLengths(col);
             let init = s.init;
             if (init && init && typeof init.instance === 'function') {
                 init = init.instance();
             }
-            if (fullName) this.declareFullReference(col.name, type, lengths, data, ignoreInit ? null : init);
-            else this.declareReference(col.name, type, lengths, data, ignoreInit ? null : init);
-            /// TODO: INIT / SEQUENCE
+            let name = col.name;
+            if (fullName) {
+                name = Context.getFullName(col.name);
+            }
+            let id = this.declareReference(col.name, type, lengths, data, ignoreInit ? null : init);
+            res.push([name, id]);
         }
+        return res;
     }
     declareFullReference(name, type, lengths = [], data = {}, initValue = null) {
         const _name = Context.getFullName(name);

--- a/src/processor.js
+++ b/src/processor.js
@@ -687,15 +687,18 @@ module.exports = class Processor {
         if (Debug.active) console.log(util.inspect(s.data, false, null, true));
         const res = this.processHintData(s.data);
         if (Debug.active) console.log(util.inspect(res, false, null, true));
-        if (this.scope.getInstanceType() === 'proof') {
+        const scopeType = this.scope.getInstanceType();
+        if (scopeType === 'proof') {
             if (Context.config.logHints) console.log(`  > define global hint \x1B[38;5;208m${name}\x1B[0m`)
             this.globalHints.define(name, res);
         }
-        else {
+        else if (scopeType == 'air') {
             if (Context.config.logHints || Context.config.logGlobalHints) {
                 console.log(`  > define hint \x1B[38;5;208m${name}\x1B[0m`)
             }
             this.hints.define(name, res);
+        } else {
+            throw new Error(`Hint definition on invalid scope (${scopeType}) ${sourceTag}`);
         }
     }
     processHintData(hdata) {

--- a/src/processor.js
+++ b/src/processor.js
@@ -698,7 +698,7 @@ module.exports = class Processor {
             }
             this.hints.define(name, res);
         } else {
-            throw new Error(`Hint definition on invalid scope (${scopeType}) ${sourceTag}`);
+            throw new Error(`Hint definition on invalid scope (${scopeType}) ${Context.sourceTag}`);
         }
     }
     processHintData(hdata) {

--- a/src/processor.js
+++ b/src/processor.js
@@ -693,7 +693,7 @@ module.exports = class Processor {
             if (Context.config.logHints) console.log(`  > define global hint \x1B[38;5;208m${name}\x1B[0m`)
             this.globalHints.define(name, res);
         }
-        else if (scopeType == 'air') {
+        else if (scopeType === 'air') {
             if (Context.config.logHints || Context.config.logGlobalHints) {
                 console.log(`  > define hint \x1B[38;5;208m${name}\x1B[0m`)
             }
@@ -1674,7 +1674,7 @@ module.exports = class Processor {
     execWitnessColDeclaration(s) {
         const features = Features.extractFeatures('witness', s.features, {stage: true});
         let res = this.declare(s, 'witness', false, true, features);
-        if (features.bits !== undefined) {            
+        if (Array.isArray(features.bits) && features.bits.length > 1) {          
             for (let [name, id] of res) {
                 let lastNameIndex = name.lastIndexOf('.');
                 if (lastNameIndex !== -1) {
@@ -1929,7 +1929,7 @@ module.exports = class Processor {
         for (const col of s.items) {
             const lengths = this.decodeLengths(col);
             let init = s.init;
-            if (init && init && typeof init.instance === 'function') {
+            if (init && typeof init.instance === 'function') {
                 init = init.instance();
             }
             let name = col.name;

--- a/src/references.js
+++ b/src/references.js
@@ -250,8 +250,7 @@ module.exports = class References {
             assert.ok(!name.includes('.object'));
         }
 
-        const nameInfo = this.decodeName(name);
-        // if (type === 'airgroupvalue') console.log(`DECLARE_REFERENCE ${name} ==> ${nameInfo.name} ${type} ${lengths.length ? '[' + lengths.join(',') + '] ': ''}scope:${nameInfo.scope} #${Context.scope.deep} ${initValue}[type: ${initValue instanceof Object ? initValue.constructor.name : typeof initValue}]`);
+        let nameInfo = this.decodeName(name);
 
         let [array, size] = Reference.getArrayAndSize(lengths);
         if (Debug.active) console.log(name, lengths, array, size);

--- a/src/sequence.js
+++ b/src/sequence.js
@@ -59,9 +59,6 @@ module.exports = class Sequence {
         };
         this.engines.typeOf.execute(this.expression);
         this.sizeOf(this.expression);
-        if (this.size > Context.rows) {
-            throw new Error(`Invalid sequence size, sequence is too large, it has size of ${this.size} but number of rows is ${Context.rows}, size exceeds in ${this.size - Context.rows}`);
-        }
         this.#values = new Values(this.bytes, this.size);
     }
     get isSequence () {

--- a/test/bug/fix_sequence_size.pil
+++ b/test/bug/fix_sequence_size.pil
@@ -1,0 +1,14 @@
+airtemplate FixSequenceSize(int N = 2**2) {
+    col fixed virtual(5) MY_VIRT_SEQ = [1,2,3,4,5];
+    // col fixed MY_SEQ = [1,2,3,4,5];
+    const int inside_groups_by_opid[2][5];
+    inside_groups_by_opid[0] = [7, 4, 5, 2, 3];
+
+}
+
+const int groups_by_opid[2][5];
+groups_by_opid[0] = [7, 4, 5, 2, 3];
+
+airgroup FixSequenceSizeGroup {
+    FixSequenceSize();
+}


### PR DESCRIPTION
- Fix hint proof-scope verification: the compiler doesn't check the proof scope when a hint was created, there are only two scopes, proof (globlal) or air. Now if the scope isn't correct an error will be reported.
- Fix sequence size control: When a sequence was created, verifies the size, but this verification must be done when assigns this sequence to fixed non virtual column. It's possible assign directly a sequence to array, in this case this verifies fail but the instruction was correct.