### PR TITLE
feature to generate hint witness_bit with information of bit column feature

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -53,9 +53,9 @@ module.exports = class Features {
         }
         return {...defaultFeatures,...featuresExtracted};
     }
-    static extractArguments(featureCls, feature) {
+    static extractArguments(featureCls, feature) {        
         const config = featureCls.config;
-        const args = feature.args.eval({clone: true}).items;
+        const args = feature.args.items;
         if (args.length < config.minArgs || args.length > config.maxArgs) {
             throw new Error(`Invalid number of arguments for feature ${feature.name} at ${Context.sourceTag}`);
         }
@@ -96,11 +96,11 @@ module.exports = class Features {
         return res;
     }   
     static getOptionArgument(arg, feature, index, argConfig) {
-        const value = ExpressionItem.value2string(arg);
+        let value = (arg.getAlone() ?? false).name ?? false;
         if (value === false) {
             throw new Error(`Invalid argument type for feature ${feature.name} at index ${index}, expected string but found ${typeof arg} at ${Context.sourceTag}`);
         }
-        if (!argConfig.values.includes(arg)) {
+        if (!argConfig.values.includes(value)) {
             throw new Error(`Invalid argument value for feature ${feature.name} at index ${index}, expected one of ${argConfig.values.join(', ')} but found ${arg} at ${Context.sourceTag}`);
         }
         return value;

--- a/src/processor.js
+++ b/src/processor.js
@@ -1673,7 +1673,20 @@ module.exports = class Processor {
     }
     execWitnessColDeclaration(s) {
         const features = Features.extractFeatures('witness', s.features, {stage: true});
-        this.declare(s, 'witness', false, true, features);
+        let res = this.declare(s, 'witness', false, true, features);
+        if (features.bits !== undefined) {            
+            for (let [name, id] of res) {
+                let lastNameIndex = name.lastIndexOf('.');
+                if (lastNameIndex !== -1) {
+                    name = name.substring(lastNameIndex + 1);
+                }
+                let hint ={name, bits: features.bits[0]};
+                if (features.bits[1] == 'signed') {
+                    hint.signed = 1;
+                }
+                this.hints.define('witness_bits', hint);
+            }
+        }
     }
     execCustomColDeclaration(s) {
         let commit = this.commits.get(s.commit);
@@ -1912,16 +1925,21 @@ module.exports = class Processor {
         return this.decodeIndexes(s.lengths);
     }
     declare(s, type, ignoreInit, fullName = true, data = {}) {
+        let res = [];
         for (const col of s.items) {
             const lengths = this.decodeLengths(col);
             let init = s.init;
             if (init && init && typeof init.instance === 'function') {
                 init = init.instance();
             }
-            if (fullName) this.declareFullReference(col.name, type, lengths, data, ignoreInit ? null : init);
-            else this.declareReference(col.name, type, lengths, data, ignoreInit ? null : init);
-            /// TODO: INIT / SEQUENCE
+            let name = col.name;
+            if (fullName) {
+                name = Context.getFullName(col.name);
+            }
+            let id = this.declareReference(col.name, type, lengths, data, ignoreInit ? null : init);
+            res.push([name, id]);
         }
+        return res;
     }
     declareFullReference(name, type, lengths = [], data = {}, initValue = null) {
         const _name = Context.getFullName(name);

--- a/src/references.js
+++ b/src/references.js
@@ -250,8 +250,7 @@ module.exports = class References {
             assert.ok(!name.includes('.object'));
         }
 
-        const nameInfo = this.decodeName(name);
-        // if (type === 'airgroupvalue') console.log(`DECLARE_REFERENCE ${name} ==> ${nameInfo.name} ${type} ${lengths.length ? '[' + lengths.join(',') + '] ': ''}scope:${nameInfo.scope} #${Context.scope.deep} ${initValue}[type: ${initValue instanceof Object ? initValue.constructor.name : typeof initValue}]`);
+        let nameInfo = this.decodeName(name);
 
         let [array, size] = Reference.getArrayAndSize(lengths);
         if (Debug.active) console.log(name, lengths, array, size);


### PR DESCRIPTION
For these columns:
```
col witness bits(10) value;
col witness bits(12, signed) carry;
```
The compiler generates these hints:
```
@witness_bits { name:"value" bits:10}
@witness_bits { name:"carry" bits:12 signed:1}
```
