### PR TITLE
Fix a bug on degree calculation for custom

### DIFF
--- a/src/expression_items/custom_col.js
+++ b/src/expression_items/custom_col.js
@@ -10,7 +10,7 @@ module.exports = class CustomCol extends ProofItem {
         if (Debug.active) console.log('CONSTRUCTOR_CUSTOM_COL', id, this.id);
     }
     get degree() {
-        return 0;
+        return 1;
     }
     getTag() {
         return 'customcol';


### PR DESCRIPTION
The builtin function degree returns 0 for custom col, now return 1 because it's as fixed column.